### PR TITLE
Worker cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,15 @@ services:
       - GRAPHQL_ADMIN_SECRET=myadminsecretkey
       - GRAPHQL_URL=http://graphql-engine:8080/v1/graphql      
     command: ["node", "./workers/worker-add-sessions.js"] 
+  worker-preload:
+    build: .
+    ports: 
+      - "8001:8001"
+    environment:
+      - REDIS_URL=redis://default:redispw@redis:6379
+      - GRAPHQL_ADMIN_SECRET=myadminsecretkey
+      - GRAPHQL_URL=http://graphql-engine:8080/v1/graphql      
+    command: ["node", "./workers/worker-preload.js"]    
   redis:
     image: redis
     ports: 

--- a/graphql/get-character-with-image.ts
+++ b/graphql/get-character-with-image.ts
@@ -1,6 +1,7 @@
-import { gqlClient } from '../app'
+import InitGraphQL from "../lib/setup-graphql";
 import { gql } from 'graphql-request'
 
+const client = InitGraphQL();
 
 const query = gql`
   query GetCharactersWithImages($show: uuid!) {
@@ -24,4 +25,4 @@ type CharactersResponse = {
 }
 
 export const getCharactersWithImages = async (variables: CharactersInput, requestHeaders: {}) =>
-  <CharactersResponse>await gqlClient.request(query, variables, requestHeaders)
+  <CharactersResponse>await client.gqlClient.request(query, variables, requestHeaders)

--- a/graphql/season-episode-counts.ts
+++ b/graphql/season-episode-counts.ts
@@ -1,6 +1,7 @@
-import { gqlClient } from '../app'
+import GraphQLInit from "../lib/setup-graphql";
 import { gql } from 'graphql-request'
 
+const client = GraphQLInit();
 
 const query = gql`
   query ShowSeasons {
@@ -26,4 +27,4 @@ type ShowSeasonsOutput = {
 }
 
 export const getSeasonsEpisodeCount = async (variables: {}, requestHeaders: {}) =>
-  <ShowSeasonsOutput>await gqlClient.request(query, variables, requestHeaders)
+  <ShowSeasonsOutput>await client.gqlClient.request(query, variables, requestHeaders)

--- a/workers/worker-preload.ts
+++ b/workers/worker-preload.ts
@@ -1,7 +1,7 @@
 import { createSessions } from "../graphql/add-sessions";
 import { getCharactersWithImages } from "../graphql/get-character-with-image";
 import { getSeasonsEpisodeCount } from "../graphql/season-episode-counts";
-import {ConnectRedis, PubSub, PushToQueue, GetQueue} from "../lib/redis";
+import { ConnectRedis, PubSub, PushToQueue, GetQueue } from "../lib/redis";
 import InitGraphQL from "../lib/setup-graphql";
 
 // ENV
@@ -12,15 +12,15 @@ const client = InitGraphQL();
 
 // Redis Pub/Sub
 const redis = ConnectRedis();
-const {subscriber, producer} = PubSub('episode-cache');
+const { subscriber, producer } = PubSub('episode-cache');
 
 
 subscriber.on("message", async (channel, message) => {
-  
+
   const { id } = JSON.parse(message);
-  
+
   const key = id;
-  
+
   for (let i = 0; i <= 10; i++) {
     const seasonEpisode = await getSeasonsEpisodeCount({}, client.adminRequestHeaders);
     const charactersWithImages = await getCharactersWithImages({ show: '950e38a3-3242-44dc-8585-fd30ced6627e' }, client.adminRequestHeaders)
@@ -29,25 +29,12 @@ subscriber.on("message", async (channel, message) => {
     const episodeCount = item.episodes_aggregate.aggregate.count
     const episode = getEpisode(episodeCount)
     let random = Math.floor(Math.random() * charactersWithImages.characters.length);
-    const character = charactersWithImages.characters[random]  
-    
-    const result = {image: character.image_url, name: character.first_name, season: season, episode: episode}
-    await PushToQueue(producer, key, {params: result})
+    const character = charactersWithImages.characters[random]
+
+    const result = { image: character.image_url, name: character.first_name, season: season, episode: episode }
+    await PushToQueue(producer, key, { params: result })
   }
-
-  return;
-  
-
-  
-  const list = await GetQueue(key, redis);
-    
-  list.length < 50 ? list : list
-    .filter(element => element.length > 0)
-    .forEach(async element => 
-      await createSessions({sessions: [JSON.parse(element)]}, client.adminRequestHeaders)
-    .then(async () => await redis.del(key)),        
-    console.log("Redis queue purged.")
-)});
+});
 
 function getEpisode(max: number): number {
   return Math.floor(Math.random() * (max - 1) + 1);

--- a/workers/worker-preload.ts
+++ b/workers/worker-preload.ts
@@ -1,0 +1,54 @@
+import { createSessions } from "../graphql/add-sessions";
+import { getCharactersWithImages } from "../graphql/get-character-with-image";
+import { getSeasonsEpisodeCount } from "../graphql/season-episode-counts";
+import {ConnectRedis, PubSub, PushToQueue, GetQueue} from "../lib/redis";
+import InitGraphQL from "../lib/setup-graphql";
+
+// ENV
+require('dotenv').config();
+
+// Ininitialize GraphQL
+const client = InitGraphQL();
+
+// Redis Pub/Sub
+const redis = ConnectRedis();
+const {subscriber, producer} = PubSub('episode-cache');
+
+
+subscriber.on("message", async (channel, message) => {
+  
+  const { id } = JSON.parse(message);
+  
+  const key = id;
+  
+  for (let i = 0; i <= 10; i++) {
+    const seasonEpisode = await getSeasonsEpisodeCount({}, client.adminRequestHeaders);
+    const charactersWithImages = await getCharactersWithImages({ show: '950e38a3-3242-44dc-8585-fd30ced6627e' }, client.adminRequestHeaders)
+    const item = seasonEpisode.seasons[Math.floor(Math.random() * seasonEpisode.seasons.length)];
+    const season = item.season_number
+    const episodeCount = item.episodes_aggregate.aggregate.count
+    const episode = getEpisode(episodeCount)
+    let random = Math.floor(Math.random() * charactersWithImages.characters.length);
+    const character = charactersWithImages.characters[random]  
+    
+    const result = {image: character.image_url, name: character.first_name, season: season, episode: episode}
+    await PushToQueue(producer, key, {params: result})
+  }
+
+  return;
+  
+
+  
+  const list = await GetQueue(key, redis);
+    
+  list.length < 50 ? list : list
+    .filter(element => element.length > 0)
+    .forEach(async element => 
+      await createSessions({sessions: [JSON.parse(element)]}, client.adminRequestHeaders)
+    .then(async () => await redis.del(key)),        
+    console.log("Redis queue purged.")
+)});
+
+function getEpisode(max: number): number {
+  return Math.floor(Math.random() * (max - 1) + 1);
+}


### PR DESCRIPTION
A new worker which caches 10 additional shuffles in the background after the first initial load. On subsequent page views, the cache is slowly depleted one-at-a-time until eventually the db is hit again and 10 more are queued up. This uses a combo of cache, pub/sub, and queues. 